### PR TITLE
fixed thumbnails of structures

### DIFF
--- a/surfaces_tools/utils/__init__.py
+++ b/surfaces_tools/utils/__init__.py
@@ -1,5 +1,10 @@
 import base64
 import io
+import math
+
+import matplotlib.pyplot as plt
+import numpy as np
+from ase.visualize.plot import plot_atoms
 
 
 def ase_to_thumbnail(structure, file_format=None):
@@ -7,7 +12,23 @@ def ase_to_thumbnail(structure, file_format=None):
 
     bytes_io = io.BytesIO()
     file_format = file_format if file_format else "png"
-    structure.write(bytes_io, format=file_format)
+    cell = structure.cell.array
+    x_extent = np.max(np.dot(cell, [1, 0, 0])) - np.min(np.dot(cell, [1, 0, 0]))
+    y_extent = np.max(np.dot(cell, [0, 1, 0])) - np.min(np.dot(cell, [0, 1, 0]))
+
+    lx = 5
+    ly = lx * y_extent / x_extent
+    if math.isnan(ly):
+        ly = 5
+    fig, ax = plt.subplots(figsize=(lx, ly))
+    plot_atoms(structure, ax=ax)
+
+    plt.axis("off")
+    plt.tight_layout()
+    plt.savefig(
+        bytes_io, dpi=75, bbox_inches="tight", format=file_format, transparent=True
+    )
+    plt.close()
     return base64.b64encode(bytes_io.getvalue()).decode()
 
 

--- a/surfaces_tools/widgets/search_structures_widget.py
+++ b/surfaces_tools/widgets/search_structures_widget.py
@@ -103,6 +103,12 @@ class SearchStructuresWidget(ipw.VBox):
 
         self.date_text = ipw.HTML(value="<p>Select the date range:</p>", width="150px")
         search_crit = ipw.HBox([self.date_text, self.date_start, self.date_end])
+        self.refresh = ipw.Checkbox(
+            value=False,
+            description="Refresh Thumbnails",
+            style={"description_width": "initial"},
+            layout={"width": "150px"},
+        )
         button = ipw.Button(description="Search")
 
         self.results = ipw.HTML()
@@ -115,7 +121,9 @@ class SearchStructuresWidget(ipw.VBox):
 
         button.on_click(on_click)
 
-        super().__init__([search_crit, button, self.results, self.info_out])
+        super().__init__(
+            [search_crit, self.refresh, button, self.results, self.info_out]
+        )
 
     def search(self):
         self.results.value = "searching..."
@@ -152,7 +160,7 @@ class SearchStructuresWidget(ipw.VBox):
                 nworkflows, workflows = uuids_to_nodesdict(node.extras["surfaces"])
             if nworkflows > 0:
                 nrows = nworkflows
-                if "thumbnail" not in node.extras:
+                if "thumbnail" not in node.extras or self.refresh.value:
                     node.base.extras.set(
                         "thumbnail", utils.ase_to_thumbnail(structure=node.get_ase())
                     )


### PR DESCRIPTION
Using ase.io.write directly to create thumbnails of the structures resulted frequently in cropped images.
We move back to a mixed ase/matplotlib approach.
Thumbnails are 75 DPI and have a widh of 5 (inches)
Added a checkbox to enable the user to regenerate all thumbnails