### PR TITLE
Convert Data to dictionary for import error handling

### DIFF
--- a/view_stm.ipynb
+++ b/view_stm.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,24 +27,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "IPython.OutputArea.prototype._should_scroll = function(lines) {\n",
-       "    return false;\n",
-       "}\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%javascript\n",
     "IPython.OutputArea.prototype._should_scroll = function(lines) {\n",
@@ -54,38 +39,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a8b36e5ebb5e474c8972e952d52bb67c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(VBox(children=(IntText(value=0, description='pk', layout=Layout(width='70%'), style=Description…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ff761714697e48d2adfbc22ffecbca83",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "colormaps = [\"gist_heat\", \"seismic\"]\n",
     "\n",
@@ -196,7 +152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,80 +183,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f1f27705c40147878d7aa4872a3ba3ca",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "VBox(children=(Button(description='Add series row', disabled=True, style=ButtonStyle()), VBox()))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e3d4245037c94aba86646ca1bbb1ff62",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Tab(children=(FloatRangeSlider(value=(0.0, 0.0), continuous_update=False, description='energy range (eV)', lay…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f47c9f01abcd419f8da942066e88d3aa",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Button(description='Plot', disabled=True, style=ButtonStyle())"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d45110b9b9e342758b2c96492df5d015",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Button(description='Clear', disabled=True, style=ButtonStyle())"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "397f02812cdc442dac2833177eb13f2b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "VBox()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "style = {\"description_width\": \"120px\"}\n",
     "layout = {\"width\": \"40%\"}\n",
@@ -347,7 +232,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -376,38 +261,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "047e2e051ce9435b8cc04696f03eb21d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(Button(description='Image zip', disabled=True, style=ButtonStyle()), FloatProgress(value=0.0, b…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f60ad84f56c34ce9a6a59483208a83c8",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "display(\n",
     "    ipw.HBox([series_plotter_inst.zip_btn, series_plotter_inst.zip_progress]),\n",
@@ -417,24 +273,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1b356c7c3b8e48acbfef5e3c848900e8",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Button(description='clear tmp', style=ButtonStyle())"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "def clear_tmp(b):\n",
     "    ! rm -rf tmp && mkdir tmp\n",
@@ -453,7 +294,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/view_stm.ipynb
+++ b/view_stm.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,9 +27,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "IPython.OutputArea.prototype._should_scroll = function(lines) {\n",
+       "    return false;\n",
+       "}\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "%%javascript\n",
     "IPython.OutputArea.prototype._should_scroll = function(lines) {\n",
@@ -39,9 +54,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a8b36e5ebb5e474c8972e952d52bb67c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(VBox(children=(IntText(value=0, description='pk', layout=Layout(width='70%'), style=Description…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ff761714697e48d2adfbc22ffecbca83",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "colormaps = [\"gist_heat\", \"seismic\"]\n",
     "\n",
@@ -58,7 +102,12 @@
     "        cp2k_calc = spm.get_calc_by_label(workcalc, \"scf_diag\")\n",
     "    except AssertionError:\n",
     "        try:\n",
-    "            dft_out_params = workcalc.outputs.dft_output_parameters.get_dict()\n",
+    "            output_parameters = workcalc.outputs.dft_output_parameters\n",
+    "\n",
+    "            if 'builtins.dict.Dict' in output_parameters.node_type:\n",
+    "                dft_out_params = output_parameters.base.attributes.all\n",
+    "            else:\n",
+    "                dft_out_params = output_parameters.get_dict()\n",
     "            new_version = True\n",
     "        except Exception as exc:\n",
     "            print(\"Incorrect pk.\")\n",
@@ -70,8 +119,12 @@
     "    # Information about the calculation.\n",
     "    with misc_info:\n",
     "        clear_output()\n",
-    "\n",
-    "    dft_inp_params = dict(workcalc.inputs[\"dft_params\"])\n",
+    "        \n",
+    "    dft_inp_params = workcalc.inputs[\"dft_params\"]\n",
+    "    if 'builtins.dict.Dict' in dft_inp_params.node_type:\n",
+    "        dft_inp_params = dft_inp_params.base.attributes.all\n",
+    "    else:\n",
+    "        dft_inp_params = dft_inp_params.get_dict()\n",
     "    if not new_version:\n",
     "        dft_out_params = dict(cp2k_calc.outputs.output_parameters)\n",
     "\n",
@@ -89,11 +142,15 @@
     "            spm_params = workcalc.inputs.stm_params\n",
     "        except common.NotExistentAttributeError:\n",
     "            spm_params = workcalc.inputs.spm_params\n",
+    "        if 'builtins.dict.Dict' in spm_params.node_type:\n",
+    "            spm_params = spm_params.base.attributes.all\n",
+    "        else:\n",
+    "            spm_params = spm_params.get_dict()\n",
     "\n",
     "        extrap_plane = float(spm_params[\"--eval_region\"][-1][1:])\n",
     "        print(f\"Extrap. plane [ang]: {extrap_plane:.1f}\")\n",
     "\n",
-    "        if \"--p_tip_ratios\" in dict(spm_params):\n",
+    "        if \"--p_tip_ratios\" in spm_params:\n",
     "            p_tip_ratio = spm_params[\"--p_tip_ratios\"]\n",
     "\n",
     "    ### Load data.\n",
@@ -139,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,9 +227,80 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f1f27705c40147878d7aa4872a3ba3ca",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(Button(description='Add series row', disabled=True, style=ButtonStyle()), VBox()))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e3d4245037c94aba86646ca1bbb1ff62",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Tab(children=(FloatRangeSlider(value=(0.0, 0.0), continuous_update=False, description='energy range (eV)', lay…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f47c9f01abcd419f8da942066e88d3aa",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Button(description='Plot', disabled=True, style=ButtonStyle())"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d45110b9b9e342758b2c96492df5d015",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Button(description='Clear', disabled=True, style=ButtonStyle())"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "397f02812cdc442dac2833177eb13f2b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "style = {\"description_width\": \"120px\"}\n",
     "layout = {\"width\": \"40%\"}\n",
@@ -219,7 +347,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -248,9 +376,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "047e2e051ce9435b8cc04696f03eb21d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(Button(description='Image zip', disabled=True, style=ButtonStyle()), FloatProgress(value=0.0, b…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f60ad84f56c34ce9a6a59483208a83c8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "display(\n",
     "    ipw.HBox([series_plotter_inst.zip_btn, series_plotter_inst.zip_progress]),\n",
@@ -260,9 +417,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1b356c7c3b8e48acbfef5e3c848900e8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Button(description='clear tmp', style=ButtonStyle())"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "def clear_tmp(b):\n",
     "    ! rm -rf tmp && mkdir tmp\n",
@@ -281,7 +453,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
This pull request updates the `view_stm.ipynb` Jupyter notebook to improve compatibility with different versions of input data. (fix import inconsistencies where `Dict` becomes `Data`)

**Data structure compatibility improvements:**
* Updated the handling of `dft_output_parameters`, `dft_params`, and `spm_params` to check for the `'builtins.dict.Dict'` node type and extract data accordingly, ensuring compatibility with both old and new data structures. 