### PR TITLE
Fix accordion title initialization

### DIFF
--- a/surfaces_tools/widgets/inputs.py
+++ b/surfaces_tools/widgets/inputs.py
@@ -160,8 +160,8 @@ class StructureInfoWidget(ipw.Accordion):
     def __init__(self):
         self.info = ipw.Output()
 
+        super().__init__(selected_index=None, children=[ipw.VBox([self.info])])
         self.set_title(0, "Structure details")
-        super().__init__(selected_index=None)
 
     @tr.observe("details")
     def _observe_details(self, _=None):
@@ -530,8 +530,6 @@ class UksSectionWidget(ipw.Accordion):
             layout={"width": "140px", "visibility": multiplicity_visibility},
         )
 
-        self.set_title(0, "Spin-polarized calculation")
-
         self.uks_box = [
             ipw.VBox(
                 [
@@ -548,9 +546,8 @@ class UksSectionWidget(ipw.Accordion):
         ]
         self.no_uks_box = [ipw.HBox([self.uks_toggle, self.charge])]
 
-        super().__init__(selected_index=None)
-
-        self.children = self.no_uks_box
+        super().__init__(selected_index=None, children=self.no_uks_box)
+        self.set_title(0, "Spin-polarized calculation")
 
     def return_dict(self):
         to_return = {
@@ -625,8 +622,6 @@ class CellSectionWidget(ipw.Accordion):
         )
         tr.link((self, "do_cell_opt"), (self.opt_cell, "value"))
 
-        self.set_title(0, "Cell optimization")
-
         super().__init__(
             selected_index=None,
             children=[
@@ -640,6 +635,7 @@ class CellSectionWidget(ipw.Accordion):
                 )
             ],
         )
+        self.set_title(0, "Cell optimization")
 
     def return_dict(self):
         sys_params = {"symmetry": self.cell_symmetry.value}


### PR DESCRIPTION
This pull request refactors the initialization of several custom widget classes in `surfaces_tools/widgets/inputs.py` to improve code clarity and ensure widget titles are set after their children are defined. The main changes involve reorganizing the order of `super().__init__()` and `set_title()` calls, and passing the widget children directly during initialization.

Widget initialization and title setting improvements:

* In `StructureInfoWidget`, the `super().__init__()` call now includes the `children` parameter, and `set_title()` is called after the children are set.
* In the spin-polarized calculation widget, the children are now passed directly to `super().__init__()` and the title is set immediately after, simplifying the initialization sequence.
* In the cell optimization widget, the title is now set after the widget's children have been defined, ensuring correct display.

Code cleanup:

* Removed redundant or misplaced `set_title()` calls that occurred before the widget's children were set, preventing potential issues with title assignment. 