### PR TITLE
Use robust atom index parsing in inputs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    aiida-core~=2.2
+    aiida-core>=2.2,<2.8
     aiida-nanotech-empa>=v1.0.0b12
     aiidalab-widgets-base[smiles]>=2.3.1,<3.0
     aiidalab-widgets-empa>=0.2.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     aiidalab-widgets-base[smiles]>=2.3.1,<3.0
     aiidalab-widgets-empa>=0.2.2
     ase>=3.24
-python_requires = >=3.10
+python_requires = >=3.9
 
 [options.extras_require]
 dev =

--- a/surfaces_tools/utils/collective_variables.py
+++ b/surfaces_tools/utils/collective_variables.py
@@ -1,9 +1,21 @@
 import ipywidgets as ipw
+import aiidalab_widgets_base as awb
 import numpy as np
 from IPython.display import clear_output, display
 
 style = {"description_width": "120px"}
 layout = {"width": "70%"}
+
+
+def _parse_atom_indices(value):
+    indices, is_valid = awb.utils.string_range_to_list(value)
+    if not is_valid:
+        raise ValueError(f"Invalid atom index range: {value!r}")
+    return [i + 1 for i in indices]
+
+
+def _format_atom_indices(indices):
+    return " ".join(str(i) for i in indices)
 
 
 class WrongCvInputError(Exception):
@@ -51,7 +63,7 @@ class DistanceCV:
 
     def read_and_validate_inputs(self):
         try:
-            a_list = [int(x) for x in self.text_colvar_atoms.value.split()]
+            a_list = _parse_atom_indices(self.text_colvar_atoms.value)
         except Exception as exc:
             raise WrongCvInputError(cv="distance") from exc
         if len(a_list) != 2:
@@ -78,7 +90,7 @@ class DistanceCV:
         return [i_a - 1 for i_a in self.a_list]
 
     def cp2k_subsys_inp(self):
-        cp2k_subsys = {"DISTANCE": {"ATOMS": self.text_colvar_atoms.value}}
+        cp2k_subsys = {"DISTANCE": {"ATOMS": _format_atom_indices(self.a_list)}}
         return cp2k_subsys
 
 
@@ -146,7 +158,7 @@ class AnglePlanePlaneCV:
 
     def read_and_validate_inputs(self):
         try:
-            self.p1_def = np.array([int(x) for x in self.text_plane1_def.value.split()])
+            self.p1_def = np.array(_parse_atom_indices(self.text_plane1_def.value))
         except Exception as exc:
             raise WrongCvInputError(
                 cv="plane-plane angle",
@@ -161,9 +173,7 @@ class AnglePlanePlaneCV:
 
         if self.p2_def_type == "ATOMS":
             try:
-                self.p2_def = np.array(
-                    [int(x) for x in self.text_plane2_def.value.split()]
-                )
+                self.p2_def = np.array(_parse_atom_indices(self.text_plane2_def.value))
             except Exception as exc:
                 raise WrongCvInputError(
                     cv="plane-plane angle",
@@ -364,8 +374,9 @@ class BondRotationCV:
 
             if typ == "GEO_CENTER":
                 try:
-                    dl = np.array(
-                        [int(x) - 1 for x in self.bond_point_textbs[i_p].value.split()]
+                    dl = (
+                        np.array(_parse_atom_indices(self.bond_point_textbs[i_p].value))
+                        - 1
                     )
                 except Exception as exc:
                     raise WrongCvInputError(cv=self.bond_point_texts[i_p]) from exc
@@ -382,7 +393,10 @@ class BondRotationCV:
                         cv=self.bond_point_texts[i_p], msg="It needs 3 x, y, z."
                     )
             self.data_list.append(dl)
-            self.data_txt_list.append(self.bond_point_textbs[i_p].value)
+            if typ == "GEO_CENTER":
+                self.data_txt_list.append(_format_atom_indices(dl + 1))
+            else:
+                self.data_txt_list.append(self.bond_point_textbs[i_p].value)
 
         self.input_received = True
 

--- a/surfaces_tools/widgets/analyze_structure.py
+++ b/surfaces_tools/widgets/analyze_structure.py
@@ -17,16 +17,7 @@ def to_ranges(iterable):
 
 
 def mol_ids_range(ismol):
-    # Shifts the list by +1.
-    range_string = ""
-    shifted_list = [i + 1 for i in ismol]
-    ranges = list(to_ranges(shifted_list))
-    for i in range(len(ranges)):
-        if ranges[i][1] > ranges[i][0]:
-            range_string += f"{ranges[i][0]}..{ranges[i][1]}"
-        else:
-            range_string += f"{ranges[i][0]} "
-    return range_string
+    return awb.utils.list_to_string_range(ismol)
 
 
 def conne_matrix(atoms):
@@ -253,13 +244,8 @@ class StructureAnalyzer(tr.HasTraits):
         return isconnected
 
     def string_range_to_list(self, a):
-        singles = [int(s) - 1 for s in a.split() if s.isdigit()]
-        ranges = [r for r in a.split() if ".." in r]
-        for r in ranges:
-            t = r.split("..")
-            to_add = [i - 1 for i in range(int(t[0]), int(t[1]) + 1)]
-            singles += to_add
-        return sorted(singles)
+        atom_indices, _ = awb.utils.string_range_to_list(a)
+        return atom_indices
 
     @tr.observe("structure")
     def _observe_structure(self, _=None):

--- a/surfaces_tools/widgets/constraints.py
+++ b/surfaces_tools/widgets/constraints.py
@@ -221,9 +221,18 @@ class ConstraintsWidget(ipw.VBox):
                     + " ,"
                 )
                 colvars += " " + c.constraint_widget.value + " ,"
-        return {
-            "sys_params": {"constraints": constraints[:-1], "colvars": colvars[:-1]}
-        }
+        constraints = constraints[:-1]
+        colvars = colvars[:-1]
+
+        try:
+            if constraints:
+                cp2k_utils.get_constraints_section(constraints)
+            if colvars:
+                cp2k_utils.get_colvars_section(colvars)
+        except ValueError as exc:
+            raise ValueError(f"Invalid constraint atom indices: {exc}") from exc
+
+        return {"sys_params": {"constraints": constraints, "colvars": colvars}}
 
     def traits_to_link(self):
         return ["details", "structure"]

--- a/surfaces_tools/widgets/inputs.py
+++ b/surfaces_tools/widgets/inputs.py
@@ -118,7 +118,10 @@ class InputDetails(ipw.VBox):
 
         # Retrieve all widgets values.
         for section in self.displayed_sections:
-            to_add = section.return_dict()
+            try:
+                to_add = section.return_dict()
+            except ValueError as exc:
+                return False, str(exc), final_dictionary
             if to_add:
                 for key in to_add.keys():
                     if key in final_dictionary.keys():
@@ -160,8 +163,8 @@ class StructureInfoWidget(ipw.Accordion):
     def __init__(self):
         self.info = ipw.Output()
 
+        super().__init__(children=[ipw.VBox([self.info])], selected_index=None)
         self.set_title(0, "Structure details")
-        super().__init__(selected_index=None)
 
     @tr.observe("details")
     def _observe_details(self, _=None):
@@ -530,8 +533,6 @@ class UksSectionWidget(ipw.Accordion):
             layout={"width": "140px", "visibility": multiplicity_visibility},
         )
 
-        self.set_title(0, "Spin-polarized calculation")
-
         self.uks_box = [
             ipw.VBox(
                 [
@@ -551,6 +552,7 @@ class UksSectionWidget(ipw.Accordion):
         super().__init__(selected_index=None)
 
         self.children = self.no_uks_box
+        self.set_title(0, "Spin-polarized calculation")
 
     def return_dict(self):
         to_return = {
@@ -561,9 +563,24 @@ class UksSectionWidget(ipw.Accordion):
         if self.uks:
             magnetization_per_site = np.zeros(self.details["numatoms"])
             for spinset in self.spins.items:
-                magnetization_per_site[
-                    awb.utils.string_range_to_list(spinset.selection.value)[0]
-                ] = spinset.starting_magnetization.value
+                atom_indices, is_valid = awb.utils.string_range_to_list(
+                    spinset.selection.value
+                )
+                if not is_valid:
+                    raise ValueError(
+                        f"Invalid spin atom indices: {spinset.selection.value!r}"
+                    )
+                if any(
+                    atom_index < 0 or atom_index >= self.details["numatoms"]
+                    for atom_index in atom_indices
+                ):
+                    raise ValueError(
+                        "Spin atom indices must be between 1 and "
+                        f"{self.details['numatoms']}."
+                    )
+                magnetization_per_site[atom_indices] = (
+                    spinset.starting_magnetization.value
+                )
             to_return.update(
                 {
                     "multiplicity": self.multiplicity.value,
@@ -625,8 +642,6 @@ class CellSectionWidget(ipw.Accordion):
         )
         tr.link((self, "do_cell_opt"), (self.opt_cell, "value"))
 
-        self.set_title(0, "Cell optimization")
-
         super().__init__(
             selected_index=None,
             children=[
@@ -640,6 +655,7 @@ class CellSectionWidget(ipw.Accordion):
                 )
             ],
         )
+        self.set_title(0, "Cell optimization")
 
     def return_dict(self):
         sys_params = {"symmetry": self.cell_symmetry.value}


### PR DESCRIPTION
## Summary
- use the shared robust parser for CV, constraint, spin, and structure-analysis atom-index fields
- block submission with a clear warning when malformed atom-index syntax is entered
- fix accordion title initialization in input detail sections
- keep the app installable in the current AiiDAlab Python 3.9 environment

## Compatibility note
This branch explicitly keeps `python_requires = >=3.9` while capping `aiida-core` to `<2.8`, so it remains compatible with the current AiiDAlab deployment target.

## Validation
- direct smoke checks for valid flexible syntax and invalid examples like `fixed 1 a 2`
- `python -m compileall surfaces_tools/utils/collective_variables.py surfaces_tools/widgets/analyze_structure.py surfaces_tools/widgets/constraints.py surfaces_tools/widgets/inputs.py`
- `git diff --check`