### PR TITLE
Add cube plane slicer

### DIFF
--- a/surfaces_tools/widgets/cube.py
+++ b/surfaces_tools/widgets/cube.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 import re
 import tempfile
 from pathlib import PurePosixPath
@@ -6,6 +7,9 @@ from pathlib import PurePosixPath
 import aiidalab_widgets_base as awb
 import ase.io.cube
 import ipywidgets as ipw
+import matplotlib.cm as cm
+import matplotlib.colors as mcolors
+import matplotlib.pyplot as plt
 import nglview
 import numpy as np
 import toml
@@ -13,6 +17,9 @@ import traitlets as tl
 from aiida import orm, plugins
 from cubehandler import Cube
 from PIL import ImageColor
+from scipy.ndimage import map_coordinates
+
+logger = logging.getLogger(__name__)
 
 CubeHandlerCalculation = plugins.CalculationFactory("nanotech_empa.cubehandler")
 Cp2kOrbitalsWorkChain = plugins.WorkflowFactory("nanotech_empa.cp2k.orbitals")
@@ -23,6 +30,66 @@ Cp2kFragmentSeparationWorkChain = plugins.WorkflowFactory(
 ISO_OPTION_PATTERN = re.compile(
     r"^\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)\s*:\s*(#[0-9A-Fa-f]{6})\s*$"
 )
+ERR_EXPECT_3_FLOATS = "Expected 3 floats"
+
+
+def _orthonormal_basis_from_normal(normal):
+    normal = np.asarray(normal, dtype=float)
+    norm = np.linalg.norm(normal)
+    if norm < 1.0e-12:
+        n_hat = np.array([0.0, 0.0, 1.0], dtype=float)
+    else:
+        n_hat = normal / norm
+
+    trial = (
+        np.array([1.0, 0.0, 0.0], dtype=float)
+        if abs(n_hat[0]) < 0.9
+        else np.array([0.0, 1.0, 0.0], dtype=float)
+    )
+    u_hat = np.cross(n_hat, trial)
+    u_hat /= np.linalg.norm(u_hat)
+    v_hat = np.cross(n_hat, u_hat)
+    v_hat /= np.linalg.norm(v_hat)
+    return n_hat, u_hat, v_hat
+
+
+def make_plane_mesh(
+    center, normal, width, height, offset=0.0, colors_2d=None, max_grid_n=64
+):
+    n_hat, u_hat, v_hat = _orthonormal_basis_from_normal(normal)
+    center = np.asarray(center, dtype=float) + float(offset) * n_hat
+    width = float(width)
+    height = float(height)
+
+    if colors_2d is None:
+        grid_n = 50
+        colors = None
+    else:
+        grid_n = min(int(max_grid_n), colors_2d.shape[0] - 1)
+        color_i = np.linspace(0, colors_2d.shape[0] - 1, grid_n, dtype=int)
+        color_j = np.linspace(0, colors_2d.shape[1] - 1, grid_n, dtype=int)
+        colors = colors_2d[np.ix_(color_i, color_j)]
+
+    us = np.linspace(-width / 2, width / 2, grid_n + 1)
+    vs = np.linspace(-height / 2, height / 2, grid_n + 1)
+    vertices = []
+    mesh_colors = []
+
+    for i in range(grid_n):
+        for j in range(grid_n):
+            u0, u1 = us[i], us[i + 1]
+            v0, v1 = vs[j], vs[j + 1]
+            p00 = center + u0 * u_hat + v0 * v_hat
+            p10 = center + u1 * u_hat + v0 * v_hat
+            p11 = center + u1 * u_hat + v1 * v_hat
+            p01 = center + u0 * u_hat + v1 * v_hat
+            color = (0.6, 0.6, 0.6) if colors is None else colors[j, i]
+
+            for point in (p00, p10, p11, p00, p11, p01):
+                vertices.extend(point.tolist())
+                mesh_colors.extend(color)
+
+    return vertices, mesh_colors
 
 
 def _normalize_color(color):
@@ -205,66 +272,579 @@ class IsovaluesWidget(ipw.VBox):
         return ["cube"]
 
 
+class CubePlaneCut2D(ipw.VBox):
+    """2D plane-cut viewer for cube data."""
+
+    cube = tl.Instance(Cube, allow_none=True)
+
+    def __init__(self):
+        self._last_r = None
+        self._last_vals = None
+        self._last_rgb = None
+        self._sinv = None
+        self._updating_color_range = False
+
+        self.center_txt = ipw.Text(
+            value="0.0 0.0 0.0",
+            description="Center (A)",
+            placeholder="x y z",
+            layout=ipw.Layout(width="420px"),
+            style={"description_width": "110px"},
+        )
+        self.normal_txt = ipw.Text(
+            value="0 0 1",
+            description="Normal",
+            placeholder="nx ny nz",
+            layout=ipw.Layout(width="420px"),
+            style={"description_width": "110px"},
+        )
+        self.offset_txt = ipw.Text(
+            value="0.0",
+            description="Offset (A)",
+            layout=ipw.Layout(width="220px"),
+            style={"description_width": "110px"},
+        )
+        self.width = ipw.FloatText(
+            value=10.0,
+            description="Width (A)",
+            layout=ipw.Layout(width="220px"),
+            style={"description_width": "110px"},
+        )
+        self.height = ipw.FloatText(
+            value=10.0,
+            description="Height (A)",
+            layout=ipw.Layout(width="220px"),
+            style={"description_width": "110px"},
+        )
+        self.res = ipw.IntSlider(
+            value=64,
+            min=32,
+            max=256,
+            step=32,
+            description="2D slice res.",
+            continuous_update=False,
+            layout=ipw.Layout(width="360px"),
+            style={"description_width": "90px"},
+        )
+        self.show_contours = ipw.Checkbox(value=False, description="2D contours")
+        self.auto_color_range = ipw.Checkbox(
+            value=True,
+            description="Auto color range",
+        )
+        self.auto_color_range.observe(self._on_auto_color_range_toggled, names="value")
+        self.vmin = ipw.FloatText(
+            value=0.0,
+            description="vmin",
+            disabled=True,
+            layout=ipw.Layout(width="150px"),
+            style={"description_width": "60px"},
+        )
+        self.vmax = ipw.FloatText(
+            value=0.0,
+            description="vmax",
+            disabled=True,
+            layout=ipw.Layout(width="150px"),
+            style={"description_width": "60px"},
+        )
+        self.show_2d_checkbox = ipw.Checkbox(value=True, description="Show 2D plot")
+        self.show_2d_checkbox.observe(self._on_show_2d_toggled, names="value")
+        self.plane_preset = ipw.Dropdown(
+            options=[
+                ("XY", "0 0 1"),
+                ("XZ", "0 1 0"),
+                ("YZ", "1 0 0"),
+            ],
+            description="Plane:",
+            layout=ipw.Layout(width="180px"),
+            style={"description_width": "55px"},
+        )
+        self.apply_plane_preset = ipw.Button(
+            description="Apply",
+            layout=ipw.Layout(width="80px"),
+        )
+        self.apply_plane_preset.on_click(self._on_apply_plane_preset)
+        self.center_on_atoms = ipw.Button(
+            description="Center on atoms",
+            layout=ipw.Layout(width="140px"),
+        )
+        self.center_on_atoms.on_click(self._on_center_on_atoms)
+        self.info = ipw.HTML("")
+        self.error = ipw.HTML("")
+        self._out = ipw.Output(
+            layout=ipw.Layout(width="560px", height="560px", border="1px solid #ddd")
+        )
+
+        super().__init__(
+            [
+                ipw.HTML("<b>2D plane cut (Cartesian point + normal, PBC)</b>"),
+                ipw.HBox([self.center_txt]),
+                ipw.HBox([self.normal_txt]),
+                ipw.HBox(
+                    [
+                        self.plane_preset,
+                        self.apply_plane_preset,
+                        self.center_on_atoms,
+                    ]
+                ),
+                ipw.HBox([self.offset_txt]),
+                ipw.HBox([self.width, self.height, self.res]),
+                ipw.HBox(
+                    [self.show_contours, self.auto_color_range, self.vmin, self.vmax]
+                ),
+                self.show_2d_checkbox,
+                self.info,
+                self.error,
+                self._out,
+            ]
+        )
+
+        for widget in (
+            self.center_txt,
+            self.normal_txt,
+            self.offset_txt,
+            self.width,
+            self.height,
+            self.res,
+            self.show_contours,
+            self.auto_color_range,
+            self.vmin,
+            self.vmax,
+        ):
+            widget.observe(self._on_any_change, names="value")
+
+    def _vec3_is_valid(self, text):
+        tokens = [token for token in re.split(r"[,\s]+", text.strip()) if token]
+        if len(tokens) != 3:
+            return False
+        try:
+            [float(token) for token in tokens]
+        except ValueError:
+            return False
+        return True
+
+    def _inputs_valid(self):
+        if self.cube is None:
+            return False
+        if not self._vec3_is_valid(self.center_txt.value):
+            return False
+        if not self._vec3_is_valid(self.normal_txt.value):
+            return False
+        try:
+            float(self.offset_txt.value)
+            float(self.width.value)
+            float(self.height.value)
+            int(self.res.value)
+        except (TypeError, ValueError):
+            return False
+        return True
+
+    def _on_any_change(self, _=None):
+        if self._updating_color_range:
+            return
+        if self._inputs_valid():
+            self.error.value = ""
+            self.plot_slice()
+        else:
+            self.error.value = ""
+            with self._out:
+                self._out.clear_output(wait=True)
+
+    def _on_show_2d_toggled(self, change):
+        if change["new"]:
+            self._out.layout.display = ""
+            if self._inputs_valid():
+                self.plot_slice()
+        else:
+            self._out.clear_output()
+            self._out.layout.display = "none"
+            if self._inputs_valid():
+                self.plot_slice()
+
+    def _on_apply_plane_preset(self, _=None):
+        self.normal_txt.value = self.plane_preset.value
+
+    def _on_center_on_atoms(self, _=None):
+        if self.cube is None:
+            return
+        center = np.mean(self.cube.ase_atoms.get_positions(), axis=0)
+        self.center_txt.value = f"{center[0]:.3f} {center[1]:.3f} {center[2]:.3f}"
+
+    def _on_auto_color_range_toggled(self, change):
+        use_auto = change["new"]
+        self.vmin.disabled = use_auto
+        self.vmax.disabled = use_auto
+        if self._inputs_valid():
+            self.plot_slice()
+
+    @staticmethod
+    def _parse_vec3(text):
+        values = np.fromstring(text.replace(",", " "), sep=" ", dtype=float)
+        if values.size != 3:
+            raise ValueError(ERR_EXPECT_3_FLOATS)
+        return values
+
+    @tl.observe("cube")
+    def _on_cube(self, _=None):
+        if self.cube is None:
+            self._sinv = None
+            self.info.value = ""
+            with self._out:
+                self._out.clear_output()
+            return
+
+        cell = np.array(self.cube.ase_atoms.cell).T
+        self._sinv = np.linalg.inv(cell)
+        center = np.mean(self.cube.ase_atoms.get_positions(), axis=0)
+        self.center_txt.value = f"{center[0]:.3f} {center[1]:.3f} {center[2]:.3f}"
+
+        nx, ny, nz = self.cube.data.shape
+        dmin = float(np.min(self.cube.data))
+        dmax = float(np.max(self.cube.data))
+        lengths = np.linalg.norm(cell, axis=0)
+        self.info.value = (
+            f"Grid: {nx} x {ny} x {nz} | data in [{dmin:.3e}, {dmax:.3e}] "
+            f"| cell lengths: {lengths[0]:.2f}, {lengths[1]:.2f}, "
+            f"{lengths[2]:.2f} A"
+        )
+        mean_len = float(np.mean(lengths))
+        self.width.value = mean_len
+        self.height.value = mean_len
+        self.plot_slice()
+
+    def _build_plane_grid(self):
+        center = self._parse_vec3(self.center_txt.value)
+        normal = self._parse_vec3(self.normal_txt.value)
+        n_hat, u_hat, v_hat = _orthonormal_basis_from_normal(normal)
+
+        offset = float(self.offset_txt.value)
+        center_shifted = center + offset * n_hat
+        width = float(self.width.value)
+        height = float(self.height.value)
+        resolution = int(self.res.value)
+
+        us = np.linspace(-width / 2, width / 2, resolution)
+        vs = np.linspace(-height / 2, height / 2, resolution)
+        uu, vv = np.meshgrid(us, vs)
+        grid = (
+            center_shifted[None, None, :]
+            + uu[..., None] * u_hat
+            + vv[..., None] * v_hat
+        )
+        extent = [-width / 2, width / 2, -height / 2, height / 2]
+        return grid, extent
+
+    def _cart_to_indexcoords(self, grid):
+        nx, ny, nz = self.cube.data.shape
+        fractional = (self._sinv @ grid.reshape(-1, 3).T).T
+        indexes = np.empty_like(fractional)
+        indexes[:, 0] = fractional[:, 0] * nx
+        indexes[:, 1] = fractional[:, 1] * ny
+        indexes[:, 2] = fractional[:, 2] * nz
+        return indexes.reshape(grid.shape)
+
+    def _compute_slice_values(self):
+        grid, extent = self._build_plane_grid()
+        index_coords = self._cart_to_indexcoords(grid)
+        coords = np.stack(
+            [index_coords[..., 0], index_coords[..., 1], index_coords[..., 2]], axis=0
+        )
+        values = map_coordinates(
+            self.cube.data, coords, order=1, mode="wrap", prefilter=False
+        )
+        return grid, extent, values
+
+    def _effective_color_range(self, values):
+        if self.auto_color_range.value:
+            return float(np.min(values)), float(np.max(values))
+        return float(self.vmin.value), float(self.vmax.value)
+
+    def _store_slice_cache(self, grid, values, vmin, vmax):
+        normalizer = mcolors.Normalize(vmin=vmin, vmax=vmax)
+        cmap = cm.get_cmap("viridis")
+        self._last_r = grid
+        self._last_vals = values
+        self._last_rgb = cmap(normalizer(values))[..., :3]
+
+    def plot_slice(self):
+        if self.cube is None:
+            return
+
+        try:
+            grid, extent, values = self._compute_slice_values()
+            vmin, vmax = self._effective_color_range(values)
+        except Exception:
+            logger.debug("cube plane slice failed", exc_info=True)
+            self.error.value = "<span style='color:#b00'>Error computing slice</span>"
+            with self._out:
+                self._out.clear_output()
+            return
+
+        if self.auto_color_range.value:
+            self._updating_color_range = True
+            try:
+                self.vmin.value = vmin
+                self.vmax.value = vmax
+            finally:
+                self._updating_color_range = False
+
+        self._store_slice_cache(grid, values, vmin, vmax)
+        if not self.show_2d_checkbox.value:
+            self._out.layout.display = "none"
+            return
+
+        self._out.layout.display = ""
+        with self._out:
+            self._out.clear_output(wait=True)
+            fig, ax = plt.subplots(figsize=(6, 6), dpi=100)
+            image = ax.imshow(
+                values,
+                origin="lower",
+                extent=extent,
+                aspect="equal",
+                vmin=vmin,
+                vmax=vmax,
+            )
+            ax.set_xlabel("u (A)")
+            ax.set_ylabel("v (A)")
+            fig.colorbar(image, ax=ax)
+
+            if self.show_contours.value and not np.isclose(vmin, vmax):
+                contour_levels = np.linspace(vmin, vmax, 9)[1:-1]
+                ax.contour(
+                    values,
+                    levels=contour_levels,
+                    origin="lower",
+                    extent=extent,
+                    colors="black",
+                    linewidths=1.2,
+                    alpha=0.65,
+                )
+                ax.contour(
+                    values,
+                    levels=contour_levels,
+                    origin="lower",
+                    extent=extent,
+                    colors="white",
+                    linewidths=0.55,
+                    alpha=0.95,
+                )
+
+            plt.show()
+            plt.close(fig)
+
+    def current_plane_params(self):
+        center = self._parse_vec3(self.center_txt.value)
+        normal = self._parse_vec3(self.normal_txt.value)
+        n_hat, _, _ = _orthonormal_basis_from_normal(normal)
+        return (
+            center,
+            n_hat,
+            float(self.offset_txt.value),
+            float(self.width.value),
+            float(self.height.value),
+        )
+
+    def return_settings(self):
+        center, normal, offset, width, height = self.current_plane_params()
+        return {
+            "center": center.tolist(),
+            "normal": normal.tolist(),
+            "offset": offset,
+            "width": width,
+            "height": height,
+            "resolution": int(self.res.value),
+            "show_2d": bool(self.show_2d_checkbox.value),
+            "show_contours": bool(self.show_contours.value),
+            "auto_color_range": bool(self.auto_color_range.value),
+            "vmin": float(self.vmin.value),
+            "vmax": float(self.vmax.value),
+        }
+
+
 class CubeArrayData3dViewerWidget(ipw.VBox):
-    """Widget to View 3-dimensional AiiDA ArrayData object in 3D."""
+    """Widget to view cube data in 3D and overlay a slicing plane."""
 
     cube = tl.Instance(Cube, allow_none=True)
 
     def __init__(self, **kwargs):
-
         self.structure = None
         self.viewer = nglview.NGLWidget()
         self.isovalues = IsovaluesWidget()
+        self._loaded_cube = None
+        self._structure_component = None
+        self._cube_component = None
+        self._plane_component = None
+        self.slice2d = None
+        self._external_plane_sync_cb = None
+
         self.show_isosurfaes_button = ipw.Button(
-            description="Show isosurfaces",
+            description="Update isosurfaces",
             layout={"width": "initial"},
             button_style="success",
         )
-        self.show_isosurfaes_button.on_click(lambda b: self.update_plot())
+        self.show_isosurfaes_button.on_click(lambda _: self.apply_isosurfaces())
+        self.show_plane_checkbox = ipw.Checkbox(
+            value=True, description="Show slicing plane in 3D"
+        )
+        self.show_plane_checkbox.observe(self._on_plane_toggle, names="value")
+        self.plane_resolution = ipw.BoundedIntText(
+            value=48,
+            min=16,
+            max=128,
+            step=16,
+            description="3D plane res.:",
+            layout=ipw.Layout(width="180px"),
+            style={"description_width": "100px"},
+        )
 
         super().__init__(
-            [self.viewer, self.isovalues, self.show_isosurfaes_button], **kwargs
+            [
+                self.viewer,
+                self.isovalues,
+                ipw.HBox(
+                    [
+                        self.show_isosurfaes_button,
+                        self.show_plane_checkbox,
+                        self.plane_resolution,
+                    ]
+                ),
+            ],
+            **kwargs,
         )
 
     @tl.observe("cube")
     def on_observe_cube(self, _=None):
         """Update object attributes when cube trait is modified."""
+        if self.cube is None:
+            self.structure = None
+            self._loaded_cube = None
+            self._remove_component("_structure_component")
+            self._remove_component("_cube_component")
+            self.hide_and_remove_plane()
+            return
+
         self.isovalues.set_range(
-            vmin=np.min(self.cube.data), vmax=np.max(self.cube.data)
+            vmin=float(np.min(self.cube.data)), vmax=float(np.max(self.cube.data))
         )
         self.structure = self.cube.ase_atoms
         self.update_plot()
 
+    def _remove_component(self, attr):
+        component = getattr(self, attr, None)
+        if component is None:
+            return
+        try:
+            self.viewer.remove_component(component.id)
+        except Exception:
+            logger.debug("remove_component failed", exc_info=True)
+        setattr(self, attr, None)
+
     def update_plot(self):
         """Update the 3D plot."""
-        while hasattr(self.viewer, "component_0"):
-            self.viewer.component_0.clear_representations()
-            self.viewer.remove_component(self.viewer.component_0.id)
-        self.setup_cube_plot()
-        try:
-            isovalues, colors = self.isovalues.return_isovalues_and_colors()
-            self.set_cube_isosurf(
-                isovalues,  # [-0.001, 0.001],
-                colors,  # ["red", "blue"],
-            )
-        except ValueError:
-            pass
+        if self._loaded_cube is self.cube and self._cube_component is not None:
+            self.apply_isosurfaces()
+            if self._external_plane_sync_cb:
+                self._external_plane_sync_cb()
+            return
 
-    def setup_cube_plot(self):
-        """Setup cube plot."""
-        self.viewer.add_component(nglview.ASEStructure(self.structure))
+        self._remove_component("_structure_component")
+        self._remove_component("_cube_component")
+        if self.structure is None or self.cube is None:
+            return
+
+        self._structure_component = self.viewer.add_component(
+            nglview.ASEStructure(self.structure)
+        )
         with tempfile.NamedTemporaryFile(mode="w") as tempf:
             ase.io.cube.write_cube(tempf, self.structure, self.cube.data)
-            c_2 = self.viewer.add_component(tempf.name, ext="cube")
-            c_2.clear()
+            self._cube_component = self.viewer.add_component(tempf.name, ext="cube")
+            self._cube_component.clear()
+        self._loaded_cube = self.cube
+        self.apply_isosurfaces()
+
+        if self._external_plane_sync_cb:
+            self._external_plane_sync_cb()
+
+    def apply_isosurfaces(self):
+        try:
+            isovalues, colors = self.isovalues.return_isovalues_and_colors()
+            self.set_cube_isosurf(isovalues, colors)
+        except ValueError:
+            pass
+        except Exception:
+            logger.debug("set_cube_isosurf failed", exc_info=True)
 
     def set_cube_isosurf(self, isovals, colors):
-        """Set cube isosurface."""
-        if hasattr(self.viewer, "component_1"):
-            c_2 = self.viewer.component_1
-            c_2.clear()
-            for isov, col in zip(isovals, colors):
-                c_2.add_surface(color=col, isolevelType="value", isolevel=isov)
+        """Set cube isosurfaces."""
+        if self._cube_component is None:
+            return
+        self._cube_component.clear()
+        for isov, col in zip(isovals, colors):
+            try:
+                self._cube_component.add_surface(
+                    color=col, isolevelType="value", isolevel=isov
+                )
+            except Exception:
+                logger.debug("add_surface failed", exc_info=True)
+
+    def _capture_newest_component_as_plane(self, before_attrs):
+        after = {name for name in dir(self.viewer) if name.startswith("component_")}
+        new_attrs = sorted(after - before_attrs)
+        if not new_attrs:
+            return
+        try:
+            self._plane_component = getattr(self.viewer, new_attrs[-1])
+        except Exception:
+            logger.debug("capturing plane component failed", exc_info=True)
+
+    def hide_and_remove_plane(self):
+        if self._plane_component is None:
+            return
+        try:
+            self.viewer.remove_component(self._plane_component.id)
+        except Exception:
+            logger.debug("remove plane component failed", exc_info=True)
+        self._plane_component = None
+
+    def _on_plane_toggle(self, change):
+        if self._external_plane_sync_cb and change["new"]:
+            self._external_plane_sync_cb()
+            return
+        if self._plane_component is None:
+            return
+        try:
+            if change["new"]:
+                self._plane_component.show()
+            else:
+                self._plane_component.hide()
+        except Exception:
+            logger.debug("plane show/hide failed", exc_info=True)
+
+    def update_plane_mesh(self, *, center, normal, width, height, offset=0.0):
+        if not self.show_plane_checkbox.value:
+            self.hide_and_remove_plane()
+            return
+
+        self.hide_and_remove_plane()
+        before = {name for name in dir(self.viewer) if name.startswith("component_")}
+        colors_2d = getattr(self.slice2d, "_last_rgb", None)
+
+        try:
+            vertices, colors = make_plane_mesh(
+                center,
+                normal,
+                width,
+                height,
+                offset,
+                colors_2d=colors_2d,
+                max_grid_n=self.plane_resolution.value,
+            )
+            self.viewer.shape.add_mesh(vertices, colors)
+        except Exception:
+            logger.debug("plane mesh update failed", exc_info=True)
+            return
+
+        self._capture_newest_component_as_plane(before)
 
 
 def render_cube_file(settings, code_uuid, render_source_remote_uuid, remote_data_uuid):
@@ -310,7 +890,6 @@ def render_cube_file(settings, code_uuid, render_source_remote_uuid, remote_data
 
 
 class HandleCubeFiles(ipw.VBox):
-
     node_pk = tl.Int(None, allow_none=True)
     nel_up = tl.Int(None, allow_none=True)
     nel_dw = tl.Int(None, allow_none=True)
@@ -321,7 +900,47 @@ class HandleCubeFiles(ipw.VBox):
 
     def __init__(self):
         self.node = None
+        self._cube_cache = {}
         self._viewer = CubeArrayData3dViewerWidget(layout=ipw.Layout(width="550px"))
+        self.slice2d = CubePlaneCut2D()
+        self._viewer.slice2d = self.slice2d
+        self._cube_sync = tl.dlink((self._viewer, "cube"), (self.slice2d, "cube"))
+
+        def _sync_plane(_=None):
+            try:
+                if self.slice2d.cube is None or not self.slice2d._inputs_valid():
+                    self._viewer.hide_and_remove_plane()
+                    return
+                center, normal, offset, width, height = (
+                    self.slice2d.current_plane_params()
+                )
+                self._viewer.update_plane_mesh(
+                    center=center,
+                    normal=normal,
+                    width=width,
+                    height=height,
+                    offset=offset,
+                )
+            except Exception:
+                logger.debug("sync plane failed", exc_info=True)
+
+        for widget in (
+            self.slice2d.center_txt,
+            self.slice2d.normal_txt,
+            self.slice2d.offset_txt,
+            self.slice2d.width,
+            self.slice2d.height,
+            self.slice2d.res,
+            self.slice2d.show_contours,
+            self.slice2d.auto_color_range,
+            self.slice2d.vmin,
+            self.slice2d.vmax,
+            self._viewer.plane_resolution,
+        ):
+            widget.observe(_sync_plane, names="value")
+
+        self._viewer._external_plane_sync_cb = _sync_plane
+        self._sync_plane = _sync_plane
         self.cube_selector = ipw.Select(
             options=[],
             description="Cube files:",
@@ -395,7 +1014,7 @@ class HandleCubeFiles(ipw.VBox):
                 # self.select_calc_widget,
                 ipw.HBox(
                     [
-                        self._viewer,
+                        ipw.VBox([self._viewer, self.slice2d]),
                         ipw.VBox(
                             [
                                 self.cube_selector,
@@ -410,12 +1029,16 @@ class HandleCubeFiles(ipw.VBox):
 
     def show_selected_cube(self, _=None):
 
-        if not self.cube_selector.value:
+        if not self.cube_selector.value or self.node is None:
             return
+        cube_name = self.cube_selector.value
         try:
-            self._viewer.cube = Cube.from_content(
-                self.node.get_object_content(f"out_cubes/{self.cube_selector.value}")
-            )
+            if cube_name not in self._cube_cache:
+                self._cube_cache[cube_name] = Cube.from_content(
+                    self.node.get_object_content(f"out_cubes/{cube_name}")
+                )
+            self._viewer.cube = self._cube_cache[cube_name]
+            self._sync_plane()
         except FileNotFoundError:
             self.error_message.value = (
                 "<span style='color:red'>Selected cube file is no longer available "
@@ -451,6 +1074,7 @@ class HandleCubeFiles(ipw.VBox):
             return
         calc = orm.load_node(self.node_pk)
         self.node = calc.outputs.retrieved
+        self._cube_cache = {}
         self.render_source_remote_uuid = calc.outputs.remote_folder.uuid
 
         parent_folders = getattr(calc.inputs, "parent_folders", None)
@@ -486,7 +1110,6 @@ class HandleCubeFiles(ipw.VBox):
         for name in cube_names:
             label = None
             if "WFN" in name:
-
                 m = pattern.search(name)
                 if not m:
                     continue  # skip unexpected names
@@ -558,11 +1181,13 @@ class HandleCubeFiles(ipw.VBox):
             self.select_calculation()
         else:
             self.node = None
+            self._cube_cache = {}
             self.cube_selector.options = []
             self._viewer.cube = None
             self.render_instructions = {}
             self.remote_data_uuid = None
             self.render_source_remote_uuid = None
+            self._viewer.hide_and_remove_plane()
 
     @tl.observe("render_instructions")
     def _observe_render_instructions(self, _=None):


### PR DESCRIPTION
## Summary

Clean replacement for the useful slicer part of #263, built on top of current `master` after the cube viewer merge.

## What changed

- Adds a 2D plane-cut widget for selected cube files.
- Adds an optional colored slicing-plane overlay in the 3D `nglview` cube viewer.
- Keeps the existing cubehandler-based cube viewer and dependency path from #226.
- Keeps high-resolution rendering marked as work in progress.

## Deliberately not included from #263

- No `core.shell` code selection.
- No `aiida_shell` / `ShellJob` usage.
- No old render calcfunction path that expected image files to exist in the working directory.
- No notebook changes beyond the cube viewer already merged on `master`.

## Validation

- `python -m ruff format surfaces_tools/widgets/cube.py`
- `python -m ruff check surfaces_tools/widgets/cube.py`
- `python -m compileall surfaces_tools/widgets/cube.py`
- `python -c "from surfaces_tools.widgets.cube import HandleCubeFiles, CubePlaneCut2D; print('cube slicer import ok')"`
- `python -c "from aiida import load_profile; load_profile(); from surfaces_tools.widgets.cube import HandleCubeFiles; w=HandleCubeFiles(); print(type(w.slice2d).__name__); print(len(w.children))"`
- scanned for `core.shell`, `aiida_shell`, `ShellJob`, and `daint`: no matches in the touched cube viewer path.
