### PR TITLE
PR-13: Structure and fragment robustness

### DIFF
--- a/surfaces_tools/widgets/analyze_structure.py
+++ b/surfaces_tools/widgets/analyze_structure.py
@@ -23,6 +23,14 @@ def boxfilter(x, thr):
     # Piero Gasparotto
 
 
+def estimate_layer_coverage(two_d_atoms, area):
+    if len(two_d_atoms) == 0:
+        return 0.0
+    if len(two_d_atoms) < 3:
+        return 1.0
+    return ConvexHull(two_d_atoms).volume / area
+
+
 def get_types(frame):  # classify the atmos in:
     # 0=molecule
     # 1=slab atoms
@@ -93,8 +101,7 @@ def get_types(frame):  # classify the atmos in:
         ]
         coverage = 0
         if len(two_d_atoms) > max_atoms_in_a_layer / 4:
-            hull = ConvexHull(two_d_atoms)
-            coverage = hull.volume / area
+            coverage = estimate_layer_coverage(two_d_atoms, area)
         if coverage > 0.3:
             found_top_surf = True
         else:
@@ -110,8 +117,7 @@ def get_types(frame):  # classify the atmos in:
         ]
         coverage = 0
         if len(two_d_atoms) > max_atoms_in_a_layer / 4:
-            hull = ConvexHull(two_d_atoms)
-            coverage = hull.volume / area
+            coverage = estimate_layer_coverage(two_d_atoms, area)
         if coverage > 0.3 and len(two_d_atoms) > max_atoms_in_a_layer / 4:
             found_bottom_surf = True
         else:

--- a/surfaces_tools/widgets/fragments.py
+++ b/surfaces_tools/widgets/fragments.py
@@ -38,6 +38,7 @@ class Fragment(ipw.VBox):
         )
 
         self.output = ipw.Output()
+        self.resources_message = awb.utils.StatusHTML()
 
         # Delete button.
         self.delete_button = ipw.Button(description="Delete", button_style="danger")
@@ -59,6 +60,7 @@ class Fragment(ipw.VBox):
                 self.charge,
                 self.output,
                 ipw.HTML("Resources:"),
+                self.resources_message,
                 self.resources,
                 self.delete_button,
             ],
@@ -76,9 +78,36 @@ class Fragment(ipw.VBox):
         self.master_class.delete_fragment(self)
 
     def estimate_computational_resources(self, whole_structure, selected_code):
-        self.structure_analyzer.structure = whole_structure[
-            string_range_to_list(self.indices.value)[0]
+        indices, is_valid = string_range_to_list(self.indices.value)
+        if not is_valid or not indices:
+            self.resources_message.message = (
+                "<span style='color:red'>Error:</span> "
+                "Select at least one atom before estimating resources."
+            )
+            return
+
+        out_of_range = [
+            index + 1
+            for index in indices
+            if index < 0 or index >= len(whole_structure)
         ]
+        if out_of_range:
+            self.resources_message.message = (
+                "<span style='color:red'>Error:</span> "
+                f"Atom indices out of range: {out_of_range}"
+            )
+            return
+
+        selected_structure = whole_structure[indices]
+        if len(selected_structure) == 0:
+            self.resources_message.message = (
+                "<span style='color:red'>Error:</span> "
+                "The selected fragment contains no atoms."
+            )
+            return
+
+        self.resources_message.message = ""
+        self.structure_analyzer.structure = selected_structure
         self.resources_estimator.details = self.structure_analyzer.details
         self.resources_estimator.selected_code = selected_code
         self.resources_estimator.estimate_resources()


### PR DESCRIPTION
Part of the surfaces split-PR chain extracted from the full working reference PR #277. This PR depends on #289 (PR-12) and should be reviewed after the earlier stacked PRs.

Scope:
- guard 2D layer coverage estimation against empty or tiny point sets before calling ConvexHull;
- show explicit fragment resource-estimation errors for empty, invalid, or out-of-range atom selections;
- keep the resource estimator from crashing on empty selections.

Files touched:
- surfaces_tools/widgets/analyze_structure.py
- surfaces_tools/widgets/fragments.py

Validation:
- python -m py_compile surfaces_tools/widgets/analyze_structure.py surfaces_tools/widgets/fragments.py
- git diff --cached --check before commit
- verified these files now match feature/cp2k-dft-options-ui exactly.