### PR TITLE
PR-14: Sync NEB resource helper

### DIFF
--- a/submit_neb.ipynb
+++ b/submit_neb.ipynb
@@ -166,6 +166,8 @@
     "    tasks_per_group_floor = max(1, total_tasks // n_groups)\n",
     "    nproc_replica = max(1, tasks_per_group_floor // n_replica_per_group)\n",
     "\n",
+    "    if int(input_details.nproc_replica_trait or 0) != nproc_replica:\n",
+    "        input_details.nproc_replica_trait = nproc_replica\n",
     "\n",
     "    return {\n",
     "        \"n_replica\": n_replica,\n",
@@ -214,6 +216,7 @@
     "for trait_name in (\n",
     "    \"n_replica_trait\",\n",
     "    \"n_replica_per_group_trait\",\n",
+    "    \"nproc_replica_trait\",\n",
     "):\n",
     "    input_details.observe(update_neb_resource_helper, trait_name)\n"
    ]


### PR DESCRIPTION
Part of the surfaces split-PR chain extracted from the full working reference PR #277. This PR depends on #290 (PR-13) and should be reviewed after the earlier stacked PRs.

Scope:
- keep the submitted NPROC_REP value synchronized with the NEB resource helper estimate;
- refresh the helper display when NPROC_REP is edited manually.

Files touched:
- submit_neb.ipynb

Validation:
- python -m json.tool submit_neb.ipynb
- git diff --cached --check before commit
- verified submit_neb.ipynb now matches feature/cp2k-dft-options-ui exactly.