### PR TITLE
Use encoded style ids for AutoRep representations

### DIFF
--- a/surfaces_tools/widgets/auto_representations.py
+++ b/surfaces_tools/widgets/auto_representations.py
@@ -149,7 +149,12 @@ class AutoRepresentationWidget(ipw.VBox):
         self.observe(self._observe_structure, names="structure")
 
     def _observe_structure(self, _=None):
-        if isinstance(getattr(self.viewer, "structure", None), Atoms):
+        structure = getattr(self.viewer, "structure", None)
+        has_stored_representations = isinstance(structure, Atoms) and any(
+            array.startswith(self.viewer.REPRESENTATION_PREFIX)
+            for array in structure.arrays
+        )
+        if isinstance(structure, Atoms) and not has_stored_representations:
             reset_default_representation(self.viewer)
         self.status.value = ""
 

--- a/surfaces_tools/widgets/auto_representations.py
+++ b/surfaces_tools/widgets/auto_representations.py
@@ -34,7 +34,14 @@ def _make_representation(
     atom_show_threshold=1,
 ):
     representation = awb_viewers.NglViewerRepresentation(
-        style_id=style_id or f"{viewer.REPRESENTATION_PREFIX}{name}",
+        style_id=style_id
+        or awb_viewers.encode_representation_style_id(
+            viewer.REPRESENTATION_PREFIX,
+            representation_type=representation_type,
+            size=3,
+            color="element",
+            token=name,
+        ),
         indices=indices,
         deletable=deletable,
         atom_show_threshold=atom_show_threshold,

--- a/tests/test_auto_representations.py
+++ b/tests/test_auto_representations.py
@@ -50,6 +50,14 @@ class AutoRepresentationsTest(unittest.TestCase):
         self.assertEqual(viewer._all_representations[0].selection.value, "3..4")
         self.assertEqual(viewer._all_representations[1].type.value, "spacefill")
         self.assertEqual(viewer._all_representations[1].selection.value, "1..2")
+        expected_style_id = viewers.encode_representation_style_id(
+            viewer.REPRESENTATION_PREFIX,
+            representation_type="spacefill",
+            size=3,
+            color="element",
+            token="non_molecule",
+        )
+        self.assertEqual(viewer._all_representations[1].style_id, expected_style_id)
 
     def test_structure_change_resets_stale_auto_representations(self):
         first_structure = Atoms(


### PR DESCRIPTION
## What

PR-S1 for surfaces AutoRep support, stacked on the existing split surfaces chain.

This PR adds AutoRep support for the encoded viewer representation IDs introduced in aiidalab-widgets-base PR-R1 (#768) and keeps imported/stored viewer representation arrays intact when structures change.

AutoRep remains surfaces-only because it uses lowdimfinder/surfaces domain logic. The widget writes molecule atoms as ball+stick and non-molecule atoms as spacefill using the same encoded representation naming convention as widgets-base.

## Dependencies

- aiidalab-widgets-base PR-R1: https://github.com/aiidalab/aiidalab-widgets-base/pull/768
- aiidalab-widgets-base PR-R2: https://github.com/aiidalab/aiidalab-widgets-base/pull/769
- aiidalab-widgets-base PR-R3: https://github.com/aiidalab/aiidalab-widgets-base/pull/770

Implemented with Codex.

## Validation

- Manually tested uploaded encoded XYZ representation arrays.
- Manually tested storing and reloading representation extras through AiiDA nodes.
- Manually tested switching from stored representation-rich structures to plain structures without stale empty rows corrupting the viewer.
- Syntax check:

```bash
python -m py_compile surfaces_tools/widgets/auto_representations.py
```
