### PR TITLE
Add PDOS projection style controls

### DIFF
--- a/surfaces_tools/widgets/pdos.py
+++ b/surfaces_tools/widgets/pdos.py
@@ -698,6 +698,27 @@ class PdosOverlapViewerWidget(ipw.VBox):
             style=style,
             layout=layout,
         )
+        self._orbital_projection_style = ipw.ToggleButtons(
+            options=[("Filled", "filled"), ("Lines", "line")],
+            value="filled",
+            description="Orbital style:",
+            style={"description_width": "100px", "button_width": "70px"},
+            layout=ipw.Layout(width="280px"),
+        )
+        self._density_min = ipw.Text(
+            value="",
+            placeholder="auto",
+            description="Y min:",
+            style={"description_width": "50px"},
+            layout=ipw.Layout(width="160px"),
+        )
+        self._density_max = ipw.Text(
+            value="",
+            placeholder="auto",
+            description="Y max:",
+            style={"description_width": "50px"},
+            layout=ipw.Layout(width="160px"),
+        )
         self._plot_output = ipw.Output()
         self._geometry_info = ipw.HTML()
         self._workchain_pk = None
@@ -741,6 +762,13 @@ class PdosOverlapViewerWidget(ipw.VBox):
                 self._plot_output,
                 self._fwhm_slider,
                 self._energy_range_slider,
+                ipw.HBox(
+                    [
+                        self._orbital_projection_style,
+                        self._density_min,
+                        self._density_max,
+                    ]
+                ),
                 ipw.HBox([plot_button, self.cumulative_plot, clear_button]),
                 self._projections,
                 self._overlap,
@@ -865,6 +893,27 @@ class PdosOverlapViewerWidget(ipw.VBox):
         with self._plot_output:
             clear_output()
 
+    def _get_density_range(self):
+        def _parse(widget):
+            text = widget.value.strip()
+            if not text:
+                return None
+            return float(text)
+
+        try:
+            density_range = [_parse(self._density_min), _parse(self._density_max)]
+        except ValueError as exc:
+            raise ValueError("Y min and Y max must be numbers or empty.") from exc
+
+        if (
+            density_range[0] is not None
+            and density_range[1] is not None
+            and density_range[0] >= density_range[1]
+        ):
+            raise ValueError("Y min must be smaller than Y max.")
+
+        return density_range
+
     def _create_the_plot(self):
         delta_e = np.min([self._fwhm_slider.value / 10, 0.005])
         elim = self._energy_range_slider.value
@@ -881,6 +930,7 @@ class PdosOverlapViewerWidget(ipw.VBox):
         ax1 = plt.gca()
 
         ylim = [None, None]
+        density_range = self._get_density_range()
 
         headers, data = self._plot_projections(ax1, ylim, energy_arr, data, headers)
         if self.do_overlap:
@@ -895,6 +945,9 @@ class PdosOverlapViewerWidget(ipw.VBox):
         plt.xlim([np.min(energy_arr), np.max(energy_arr)])
         if ncol == 1:
             ylim[0] = 0.0
+        for i_limit, limit in enumerate(density_range):
+            if limit is not None:
+                ylim[i_limit] = limit
         plt.ylim(ylim)
         plt.axhline(0.0, color="k", lw=2.0, zorder=200)
         plt.ylabel("Density of States [a.u.]")
@@ -976,15 +1029,26 @@ class PdosOverlapViewerWidget(ipw.VBox):
             else:
                 cumulative_plot[spin] = series
 
-            ax1.fill_between(
-                energy_arr,
-                0.0,
-                cumulative_plot[spin] * (-2 * spin + 1),
-                facecolor=picked_color,
-                alpha=1.0,
-                zorder=-i_serie + 100,
-                label=label,
-            )
+            plot_series = cumulative_plot[spin] * (-2 * spin + 1)
+            if self._orbital_projection_style.value == "line":
+                ax1.plot(
+                    energy_arr,
+                    plot_series,
+                    color=picked_color,
+                    lw=1.6,
+                    zorder=-i_serie + 100,
+                    label=label,
+                )
+            else:
+                ax1.fill_between(
+                    energy_arr,
+                    0.0,
+                    plot_series,
+                    facecolor=picked_color,
+                    alpha=1.0,
+                    zorder=-i_serie + 100,
+                    label=label,
+                )
 
             collect_data_headers.append(f"{label} s{spin}")
             collect_data = np.vstack([collect_data, series])


### PR DESCRIPTION
## Summary
- add an orbital-projection style selector to the PDOS viewer: filled areas remain the default, with an optional line-only mode using the same colors
- add optional Y min / Y max density controls; empty fields keep the existing automatic limits
- leave ordinary PDOS/TDOS plotting unchanged

## Context
Stacked on top of the current surfaces work in feature/auto-rep-encoded-style-ids so the diff stays focused on this PDOS visualization feature.

## Validation
- python -m py_compile surfaces_tools/widgets/pdos.py
- instantiated PdosOverlapViewerWidget and checked the new default controls

Done with Codex.