### PR TITLE
Map LowDimFinder IDs to the input cell

### DIFF
--- a/surfaces_tools/widgets/lowdimfinder.py
+++ b/surfaces_tools/widgets/lowdimfinder.py
@@ -1350,7 +1350,9 @@ class LowDimFinder:
             "chemical_formula": self._chemical_formula,
             "positions": self._positions,
             "chemical_symbols": self._chemical_symbols,
-            "unit_cell_ids": self._unit_cell_groups,
+            "unit_cell_ids": [
+                [idx % self.n_unit for idx in group] for group in self._unit_cell_groups
+            ],
             "cell": self._cell,
             "tags": self._tags,
         }

--- a/tests/test_lowdimfinder_contract.py
+++ b/tests/test_lowdimfinder_contract.py
@@ -11,8 +11,9 @@ class LowDimFinderContractTest(unittest.TestCase):
         finder._chemical_formula = ["C"]
         finder._positions = [[[0.0, 0.0, 0.0]]]
         finder._chemical_symbols = [["C"]]
-        finder._unit_cell_groups = [[0]]
+        finder.n_unit = 2
+        finder._unit_cell_groups = [[3]]
         finder._cell = [[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]]
         finder._tags = [[0]]
 
-        self.assertEqual(finder.get_group_data()["unit_cell_ids"], [[0]])
+        self.assertEqual(finder.get_group_data()["unit_cell_ids"], [[1]])


### PR DESCRIPTION
## Summary

Map atom indices selected from the periodic LowDimFinder supercell back to the original input-cell indices before exposing `unit_cell_ids`. This prevents downstream structure analysis from indexing the original structure with supercell-local IDs.

## Validation

- `pytest -q tests/test_lowdimfinder_contract.py`
- `python -m py_compile surfaces_tools/widgets/lowdimfinder.py tests/test_lowdimfinder_contract.py`
- Ruff format/check, end-of-file, trailing-whitespace, and `git diff --check` passed

The aggregate pre-commit run could not create the Go-based `yamlfmt` environment because the ARM64 Go toolchain invoked the container's x86 assembler; `mypy` is not installed locally.

Prepared with Codex assistance.