### PR TITLE
Explain the NEB resource layout in the submission form

### DIFF
--- a/submit_neb.ipynb
+++ b/submit_neb.ipynb
@@ -196,7 +196,18 @@
     "    if \"restart_from\" in parameters:\n",
     "        builder.restart_from = orm.Str(parameters[\"restart_from\"])\n",
     "\n",
-    "    return builder"
+    "    return builder\n",
+    "\n",
+    "\n",
+    "# Opt-in explainer for how the requested allocation is split into replica\n",
+    "# groups. Off by default: it answers an occasional question, it is not\n",
+    "# something every submission needs to look at.\n",
+    "neb_resource_box = neb_resources.NebResourceHelper(_neb_resource_info)\n",
+    "\n",
+    "resources.nodes_widget.observe(neb_resource_box.update, \"value\")\n",
+    "resources.tasks_per_node_widget.observe(neb_resource_box.update, \"value\")\n",
+    "input_details.observe(neb_resource_box.update, \"n_replica_trait\")\n",
+    "input_details.observe(neb_resource_box.update, \"n_replica_per_group_trait\")"
    ]
   },
   {
@@ -268,7 +279,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "display(code_input_widget, ipw.HBox([resources, resources_estimation_button]))"
+    "display(\n",
+    "    code_input_widget,\n",
+    "    ipw.HBox([resources, resources_estimation_button]),\n",
+    "    neb_resource_box,\n",
+    ")"
    ]
   },
   {

--- a/surfaces_tools/utils/neb_resources.py
+++ b/surfaces_tools/utils/neb_resources.py
@@ -20,9 +20,15 @@ those tasks over time rather than splitting them.  Dividing again would leave
 Every input is floored at 1 before use.  The resource widgets are unbounded
 integer fields, so a mistyped node count or an allocation smaller than the
 replica count could otherwise produce ``NPROC_REP = 0``, which CP2K rejects.
+
+``NebResourceHelper`` is the opt-in panel that puts the layout into words for
+the submission form.  It lives here rather than in the notebook so that it can
+be tested; nothing in a notebook cell can be.
 """
 
 import math
+
+import ipywidgets as ipw
 
 
 def at_least(value, minimum=1):
@@ -70,3 +76,65 @@ def resource_layout(
         "tasks_per_group": total_tasks / n_groups,
         "nproc_replica": at_least(total_tasks // n_groups),
     }
+
+
+class NebResourceHelper(ipw.VBox):
+    """Opt-in panel explaining how an allocation splits into replica groups.
+
+    ``layout_provider`` is called on every refresh and must return a
+    ``resource_layout`` result.  It is a callable rather than the resource
+    widgets themselves because the caller owns those widgets and the clamping
+    applied to them; this panel only reads what it is handed.
+
+    Hook ``update`` up as a traitlets observer on anything that feeds the
+    layout.  The checkbox is observed here, so callers do not repeat it.
+    """
+
+    def __init__(self, layout_provider, **kwargs):
+        self._layout_provider = layout_provider
+        self.show = ipw.Checkbox(
+            value=False,
+            description="Show NEB resource helper",
+            indent=False,
+            style={"description_width": "initial"},
+        )
+        self.text = ipw.HTML()
+        self.show.observe(self.update, "value")
+        super().__init__([self.show, self.text], **kwargs)
+        self.update()
+
+    def update(self, _=None):
+        """Re-render the panel, or clear it while the box is unchecked."""
+        self.text.value = self.describe_layout() if self.show.value else ""
+
+    def describe_layout(self):
+        """Render the current layout as one HTML sentence.
+
+        Warns when the MPI tasks do not divide evenly between the groups,
+        which is the case that leaves part of the allocation idle.  Note the
+        test is on the tasks, not on the nodes: half a node per group wastes
+        nothing as long as the tasks come out whole, and that is a layout the
+        resources widget produces deliberately.
+
+        ``threads_per_task`` is left out on purpose - it is clamped alongside
+        the rest but plays no part in the grouping.
+        """
+        layout = self._layout_provider()
+        tasks_per_group = layout["tasks_per_group"]
+        text = (
+            f"{layout['n_replica']} replicas at {layout['n_replica_per_group']} "
+            f"per group run as <b>{layout['n_groups']} replica group(s)</b>. "
+            f"{layout['nodes']} nodes x {layout['tasks_per_node']} tasks per "
+            f"node are shared as {layout['nodes'] / layout['n_groups']:g} "
+            f"node(s), i.e. {tasks_per_group:g} MPI tasks, per group, so "
+            f"<b>NPROC_REP = {layout['nproc_replica']}</b>. "
+            "The threads per task do not enter this split."
+        )
+        if tasks_per_group != int(tasks_per_group):
+            text += (
+                " <b>The tasks do not divide evenly between the groups</b>, so "
+                f"{layout['nproc_replica']} tasks per group leaves part of the "
+                "allocation idle. Adjust the total number of nodes or the "
+                "number of replicas per group."
+            )
+        return f"<p>{text}</p>"

--- a/tests/test_neb_resources.py
+++ b/tests/test_neb_resources.py
@@ -1,6 +1,10 @@
 import unittest
 
-from surfaces_tools.utils.neb_resources import at_least, resource_layout
+from surfaces_tools.utils.neb_resources import (
+    NebResourceHelper,
+    at_least,
+    resource_layout,
+)
 
 
 class AtLeastTest(unittest.TestCase):
@@ -72,3 +76,104 @@ class ResourceLayoutTest(unittest.TestCase):
         # share those 32 tasks in turn rather than splitting them.
         self.assertEqual(layout["n_groups"], 4)
         self.assertEqual(layout["nproc_replica"], 32)
+
+
+def helper_showing(**layout_kwargs):
+    """A panel whose provider always hands back one fixed layout."""
+    return NebResourceHelper(lambda: resource_layout(**layout_kwargs))
+
+
+class DescribeLayoutTest(unittest.TestCase):
+    def test_reports_the_grouping_and_nproc_rep(self):
+        text = helper_showing(
+            n_replica=15,
+            n_replica_per_group=3,
+            nodes=5,
+            tasks_per_node=32,
+            threads_per_task=4,
+        ).describe_layout()
+
+        self.assertIn("5 replica group(s)", text)
+        self.assertIn("32 MPI tasks", text)
+        self.assertIn("NPROC_REP = 32", text)
+
+    def test_stays_quiet_when_the_tasks_divide_evenly(self):
+        # Half a node per group, but 16 whole tasks each: nothing is idle, and
+        # this is a layout the resources widget produces on purpose.
+        text = helper_showing(
+            n_replica=8,
+            n_replica_per_group=2,
+            nodes=2,
+            tasks_per_node=32,
+            threads_per_task=4,
+        ).describe_layout()
+
+        self.assertIn("0.5 node(s)", text)
+        self.assertNotIn("do not divide evenly", text)
+
+    def test_warns_when_the_tasks_do_not_divide_evenly(self):
+        # 96 tasks over 7 groups: 13 each, leaving 5 idle.
+        text = helper_showing(
+            n_replica=7,
+            n_replica_per_group=1,
+            nodes=3,
+            tasks_per_node=32,
+            threads_per_task=4,
+        ).describe_layout()
+
+        self.assertIn("do not divide evenly", text)
+        self.assertIn("NPROC_REP = 13", text)
+
+
+class NebResourceHelperTest(unittest.TestCase):
+    def setUp(self):
+        self.calls = 0
+        self.nodes = 5
+
+    def provider(self):
+        self.calls += 1
+        return resource_layout(
+            n_replica=15,
+            n_replica_per_group=3,
+            nodes=self.nodes,
+            tasks_per_node=32,
+            threads_per_task=4,
+        )
+
+    def test_starts_empty_without_consulting_the_provider(self):
+        helper = NebResourceHelper(self.provider)
+
+        self.assertFalse(helper.show.value)
+        self.assertEqual(helper.text.value, "")
+        self.assertEqual(self.calls, 0)
+
+    def test_checking_the_box_renders_the_layout(self):
+        helper = NebResourceHelper(self.provider)
+
+        helper.show.value = True
+
+        self.assertIn("NPROC_REP = 32", helper.text.value)
+
+    def test_unchecking_the_box_clears_the_panel(self):
+        helper = NebResourceHelper(self.provider)
+        helper.show.value = True
+
+        helper.show.value = False
+
+        self.assertEqual(helper.text.value, "")
+
+    def test_update_refreshes_while_shown_and_is_inert_while_hidden(self):
+        helper = NebResourceHelper(self.provider)
+        helper.show.value = True
+
+        # update() is registered as an observer on the node count and friends,
+        # so it is called with a change dict it ignores.
+        self.nodes = 15
+        helper.update({"name": "value", "new": 15})
+        self.assertIn("NPROC_REP = 96", helper.text.value)
+
+        helper.show.value = False
+        calls_while_hidden = self.calls
+        helper.update()
+        self.assertEqual(helper.text.value, "")
+        self.assertEqual(self.calls, calls_while_hidden)


### PR DESCRIPTION
Users had no way to see how nodes and tasks are split across replica groups, or why NPROC_REP ended up at a particular value - the number appeared read-only with no derivation. To fix that, we introduce NebResourceHelper, that describe the group count, nodes and MPI tasks per group and the resulting NPROC_REP.