### PR TITLE
Run the test suite in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: Tests
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -e .[dev]
+      - run: pytest

--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ Features include:
 * Atomic force microscopy (AFM) simulations - calls the [ProbeParticle](https://github.com/ProkopHapala/ProbeParticleModel) code.
 * High-resolution STM - simulates the STM/STS signatures performed with the CO tip.
 
+## Running the tests
+
+Install the development dependencies and run the suite with pytest:
+
+```
+pip install -e .[dev]
+pytest
+```
+
 ## For maintainers
 
 To create a new release, clone the repository, install development dependencies with `pip install '.[dev]'`, and then execute `bumpver update --dry --major (--minor/--patch)`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,5 @@
 [tool.ruff]
 builtins = ["jupyter_notebook_url"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ dev =
     bumpver==2022.1119
     mypy
     pre-commit~=4.3
+    pytest~=8.0
 
 [aiidalab]
 title = Empa nanotech@surfaces Laboratory - On-Surface Chemistry


### PR DESCRIPTION
The only workflow was a tag-triggered release job, so nothing ran the tests on a push or pull request.

- Add .github/workflows/test.yml running pytest on push to master and on pull request, on Python 3.12 to match the AiiDAlab image.
- Add pytest~=8.0 to the dev extras and set testpaths in pyproject.toml.
- Document how to run the tests in the README.